### PR TITLE
Fix tooltip scoring regression for non-bag items (regression from v2.4.4)

### DIFF
--- a/Judge.lua
+++ b/Judge.lua
@@ -591,27 +591,37 @@ function MSC.EvaluateAndDrawTooltip(tooltip)
     -- [[ 3. RUN VISUAL UPDATES FIRST ]]
     if MSC.BeautifyTooltip then MSC:BeautifyTooltip(tooltip) end
 
-    -- [[ 4. SCORING VISIBILITY CHECK ]]
-    if not tooltip:IsVisible() and not MSC.IsQuestHook then return end
-    
+    -- [[ 4. VALIDATE ITEM (synchronous -- no item data needed) ]]
+    if not link or not IsEquippableItem(link) or not MSC.IsItemUsable(link) then
+        return
+    end
+
+    -- [[ 5. ITEM DATA GATEKEEPER ]]
+    -- Defer when EITHER the item data isn't cached yet (GetItemInfo nil) OR the tooltip
+    -- isn't visible yet (chat links / ItemRefTooltip still being constructed).
+    -- Bag/inventory items satisfy both synchronously -> no deferral, no flicker.
+    local itemName = GetItemInfo(link)
+    if not itemName or (not tooltip:IsVisible() and not MSC.IsQuestHook) then
+        C_Timer.After(0, function()
+            if tooltip:IsVisible() or MSC.IsQuestHook then
+                MSC.EvaluateAndDrawTooltip(tooltip)
+            end
+        end)
+        return
+    end
+
+    -- [[ 6. SCORING DUPLICATE GUARD ]]
+    -- (visibility is guaranteed by the gatekeeper above)
     if tooltipName then
         for i = 2, tooltip:NumLines() do
             local leftLine = _G[tooltipName .. "TextLeft" .. i]
             if leftLine and leftLine:GetText() and string_find(leftLine:GetText(), MSC.L["Judge's Score:"] or "Judge's Score:") then
-                return 
+                return
             end
         end
     end
 
-    -- [[ 5. VALIDATE ITEM & SERVER GATEKEEPER ]]
-    if not link or not IsEquippableItem(link) or not MSC.IsItemUsable(link) then 
-        return 
-    end
-    
-    local itemName = GetItemInfo(link)
-    if not itemName then return end
-
-    MSC.IsCalculating = true 
+    MSC.IsCalculating = true
 
     -- [[ 6. RUN SCORING ENGINE ]]
     local _, playerClass = UnitClass("player")


### PR DESCRIPTION
v2.4.4 removed the C_Timer.After(0) deferral that previously wrapped all scoring work. For items not in the client cache (AH, vendor, chat links, quest rewards, atlasloot), WoW fires OnTooltipSetItem before it has fetched item data. Without the deferral, the synchronous visibility check fired immediately, returned early, and no score was ever drawn. Bag items were unaffected because their data is always cached.

A previous patch attempt re-added C_Timer.After(0) only after the GetItemInfo nil check — but the visibility check ran before that and exited first, so the timer was never reached.

The defer condition is now a two-part gate checked before any visibility logic:
  ```
  if not itemName or (not tooltip:IsVisible() and not MSC.IsQuestHook) then
      C_Timer.After(0, function()
          if tooltip:IsVisible() or MSC.IsQuestHook then
              MSC.EvaluateAndDrawTooltip(tooltip)
          end
      end)
      return
  end
```
Defer fires when either GetItemInfo returns nil (data not yet cached) or the tooltip isn't visible yet (e.g. ItemRefTooltip still being constructed for a chat link). Items already in the cache with a visible tooltip — i.e. bag items — pass through immediately with no deferral and no flicker.     

The duplicate-score guard (TSM loop prevention from v2.4.4) is preserved and moved after the gate, where it remains effective.

Works for me

Give this a once over before merging in. I am not a LUA guy by trade. Just want this sweet addon to work again.

Appreciate the hard work.