### PR TITLE
Fix Project Best enchant double counted in stats

### DIFF
--- a/Helpers.lua
+++ b/Helpers.lua
@@ -426,6 +426,53 @@ function MSC.GetBestEnchantForSlot(slotId, level, specName, enchantType, weights
     return (bestScore > 0) and bestID or nil
 end
 
+local function InferCurrentEnchantFromDelta(slotId, rawStats, baseRaw)
+    if not slotId or not rawStats or not baseRaw or not MSC.EnchantDB then return nil end
+
+    local candidates = MSC.EnchantCandidates and MSC.EnchantCandidates[slotId]
+    if not candidates then return nil end
+
+    local bestMatch, bestTotal = nil, 0
+
+    for _, enchantID in ipairs(candidates) do
+        local data = MSC.EnchantDB[enchantID]
+        if data and data.stats then
+            local matched = true
+            local total = 0
+
+            for statKey, statVal in pairs(data.stats) do
+                if type(statVal) == "number" then
+                    local rawDelta = math_max(0, (rawStats[statKey] or 0) - (baseRaw[statKey] or 0))
+                    if math_abs(rawDelta - statVal) > 0.01 then
+                        matched = false
+                        break
+                    end
+                    total = total + statVal
+                end
+            end
+
+            if matched then
+                for statKey, rawVal in pairs(rawStats) do
+                    if type(rawVal) == "number" then
+                        local rawDelta = math_max(0, rawVal - (baseRaw[statKey] or 0))
+                        local enchantVal = data.stats[statKey] or 0
+                        if math_abs(rawDelta - enchantVal) > 0.01 then
+                            matched = false
+                            break
+                        end
+                    end
+                end
+            end
+
+            if matched and total > bestTotal then
+                bestMatch, bestTotal = data, total
+            end
+        end
+    end
+
+    return bestMatch
+end
+
 function MSC.GetBestGemForSocket(socketColor, level, weights, excludeList, isJC)
     local bestGem, bestScore = nil, 0
     local db = (level >= 60 and MSC.GemOptions) and MSC.GemOptions or MSC.GemOptions_Leveling
@@ -586,19 +633,22 @@ local enchantMode = SGJ_Settings and SGJ_Settings.EnchantMode or 1
 
     if physicalEnchantID > 0 and MSC.EnchantDB and MSC.EnchantDB[physicalEnchantID] then
         currentEnchantData = MSC.EnchantDB[physicalEnchantID]
-        if currentEnchantData.stats then
-            for k, v in pairs(currentEnchantData.stats) do
-                if type(v) == "number" then
-                    local removable = v
-                    if baseRaw then
-                        removable = math_min(v, math_max(0, (rawStats[k] or 0) - (baseRaw[k] or 0)))
-                    elseif (finalStats[k] or 0) < v then
-                        removable = 0
-                    end
+    elseif baseRaw then
+        currentEnchantData = InferCurrentEnchantFromDelta(derivedSlotId, rawStats, baseRaw)
+    end
 
-                    if removable > 0 then
-                        finalStats[k] = math_max(0, (finalStats[k] or 0) - removable)
-                    end
+    if currentEnchantData and currentEnchantData.stats then
+        for k, v in pairs(currentEnchantData.stats) do
+            if type(v) == "number" then
+                local removable = v
+                if baseRaw then
+                    removable = math_min(v, math_max(0, (rawStats[k] or 0) - (baseRaw[k] or 0)))
+                elseif (finalStats[k] or 0) < v then
+                    removable = 0
+                end
+
+                if removable > 0 then
+                    finalStats[k] = math_max(0, (finalStats[k] or 0) - removable)
                 end
             end
         end
@@ -642,16 +692,6 @@ local enchantMode = SGJ_Settings and SGJ_Settings.EnchantMode or 1
                 if bestID and MSC.EnchantDB[bestID] then
                     local bestData = MSC.EnchantDB[bestID]
                     if bestData.stats then
-                        if not currentEnchantData and baseRaw then
-                            for k, v in pairs(bestData.stats) do
-                                if type(v) == "number" then
-                                    local rawDelta = math_max(0, (rawStats[k] or 0) - (baseRaw[k] or 0))
-                                    if rawDelta > 0 then
-                                        finalStats[k] = math_max(0, (finalStats[k] or 0) - math_min(v, rawDelta))
-                                    end
-                                end
-                            end
-                        end
                         for k, v in pairs(bestData.stats) do 
                             if type(v) == "number" then finalStats[k] = (finalStats[k] or 0) + v end
                         end

--- a/Helpers.lua
+++ b/Helpers.lua
@@ -554,12 +554,13 @@ function MSC.SafeGetItemStats(itemLink, slotId, weights, specName, globalUniques
     local finalStats = {}
     for k,v in pairs(rawStats) do if k ~= "_BONUS_STATS" then finalStats[k] = v end end
     local bonusStats = rawStats._BONUS_STATS or {}
+    local baseLink = MSC.GetBaseLink and MSC.GetBaseLink(itemLink) or nil
+    local baseRaw = nil
 
-    if not next(bonusStats) and MSC.GetBaseLink then
-        local baseLink = MSC.GetBaseLink(itemLink)
-        if baseLink and baseLink ~= itemLink then
-            local baseRaw = MSC.GetRawItemStats(baseLink)
-            if baseRaw._BONUS_STATS and next(baseRaw._BONUS_STATS) then bonusStats = baseRaw._BONUS_STATS end
+    if baseLink and baseLink ~= itemLink then
+        baseRaw = MSC.GetRawItemStats(baseLink)
+        if not next(bonusStats) and baseRaw._BONUS_STATS and next(baseRaw._BONUS_STATS) then
+            bonusStats = baseRaw._BONUS_STATS
         end
     end
 
@@ -631,6 +632,16 @@ local enchantMode = SGJ_Settings and SGJ_Settings.EnchantMode or 1
                 if bestID and MSC.EnchantDB[bestID] then
                     local bestData = MSC.EnchantDB[bestID]
                     if bestData.stats then
+                        if not currentEnchantData and baseRaw then
+                            for k, v in pairs(bestData.stats) do
+                                if type(v) == "number" then
+                                    local rawDelta = math_max(0, (rawStats[k] or 0) - (baseRaw[k] or 0))
+                                    if rawDelta > 0 then
+                                        finalStats[k] = math_max(0, (finalStats[k] or 0) - math_min(v, rawDelta))
+                                    end
+                                end
+                            end
+                        end
                         for k, v in pairs(bestData.stats) do 
                             if type(v) == "number" then finalStats[k] = (finalStats[k] or 0) + v end
                         end

--- a/Helpers.lua
+++ b/Helpers.lua
@@ -577,6 +577,7 @@ local enchantMode = SGJ_Settings and SGJ_Settings.EnchantMode or 1
     end
     
     local physicalEnchantID = 0
+    local currentEnchantData = nil
     local itemString = string_match(itemLink, "item[%-?%d:]+")
     if itemString then
         local _, _, eid = strsplit(":", itemString)
@@ -584,11 +585,20 @@ local enchantMode = SGJ_Settings and SGJ_Settings.EnchantMode or 1
     end
 
     if physicalEnchantID > 0 and MSC.EnchantDB and MSC.EnchantDB[physicalEnchantID] then
-        local pData = MSC.EnchantDB[physicalEnchantID]
-        if pData.stats then
-            for k, v in pairs(pData.stats) do
-                if type(v) == "number" and (finalStats[k] or 0) >= v then
-                    finalStats[k] = finalStats[k] - v
+        currentEnchantData = MSC.EnchantDB[physicalEnchantID]
+        if currentEnchantData.stats then
+            for k, v in pairs(currentEnchantData.stats) do
+                if type(v) == "number" then
+                    local removable = v
+                    if baseRaw then
+                        removable = math_min(v, math_max(0, (rawStats[k] or 0) - (baseRaw[k] or 0)))
+                    elseif (finalStats[k] or 0) < v then
+                        removable = 0
+                    end
+
+                    if removable > 0 then
+                        finalStats[k] = math_max(0, (finalStats[k] or 0) - removable)
+                    end
                 end
             end
         end


### PR DESCRIPTION
Fix Project Best enchant double counting on pre-enchanted items
 
 When Enchant Mode is set to Project Best, some already-enchanted items could have their baked-in enchant value counted in raw stats and then receive the projected enchant a second time during evaluation.
 
Compare against the base item stats and strip any  enchant-like delta before adding the projected best enchant, so pre-enchanted items are evaluated with only one enchant applied.